### PR TITLE
Update browserslist so that browser ranges work

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/anandthakker/doiuse",
   "dependencies": {
-    "browserslist": "^0.3.1",
+    "browserslist": "^0.5.0",
     "caniuse-db": "^1.0.30000187",
     "css-rule-stream": "^1.1.0",
     "duplexer2": "0.0.2",


### PR DESCRIPTION
Browserslist 0.3.3 complains about (some?) browser ranges: 

    Error: Unknown browser query `ios_saf 8.1-8.4`

0.5.0 does not seem to have this problem.