### PR TITLE
Update browserslist, which supports browser ranges correctly

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -58,11 +58,12 @@ if (argv.verbose >= 1) {
   console.log('[doiuse] Browsers: ' + browsers)
 }
 
+var out
 if (argv.verbose >= 2) {
   var features = require('./')(argv.browsers).info().features
   console.log('\n[doiuse] Unsupported features:')
   for (var feat in features) {
-    var out = [features[feat].caniuseData.title]
+    out = [features[feat].caniuseData.title]
     if (argv.verbose >= 3) {
       out.push('\n', features[feat].missing.join(', '), '\n')
     }
@@ -77,7 +78,6 @@ if (argv.help || (argv._.length === 0 && process.stdin.isTTY)) {
   process.exit()
 }
 
-var out
 if (argv.json) {
   out = ldjson.serialize()
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/anandthakker/doiuse",
   "dependencies": {
-    "browserslist": "^0.3.1",
+    "browserslist": "^0.5.0",
     "caniuse-db": "^1.0.30000187",
     "css-rule-stream": "^1.1.0",
     "duplexer2": "0.0.2",


### PR DESCRIPTION
browserslist 0.3.3 has issues handling browser ranges 

    Error: Unknown browser query `ios_saf 8.1-8.4` 