### PR TITLE
Add array of ignoring rules, per issue #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@ doiuse
 
 Lint CSS for browser support against caniuse database.
 
-**NOTE:** This is a very, very initial release.  Feedback or contributions
-are quite welcome!
-
 # Install
 
 ```sh
@@ -25,7 +22,7 @@ npm run babel
 That last step transpiles the ES6 from src/ to ES5 in lib/. Already happens as a `pretest` step for `npm test`.
 
 
-# Usage
+# Usage Examples
 
 ## Command Line
 ```bash
@@ -65,28 +62,38 @@ postcss(doiuse({
 })).process("a { background-size: cover; }")
 ```
 
+## Gulp
+
+```javascript
+var gulp = require('gulp')
+var postcss = require('postcss')
+var doiuse = require('doiuse')
+
+gulp.src(src, { cwd: process.cwd() })
+.pipe(gulp.postcss([
+  doiuse({
+    browsers: [
+      'ie >= 8',
+      '> 1%'
+    ],
+    onFeatureUsage: function (usageInfo) {
+      console.log(usageInfo.message)
+    }
+  })
+]))
+```
+
 # How it works
 In particular, the approach to detecting features usage is currently quite naive.
 
-Refer to the data in /src/data/features.coffee.
+Refer to the data in /src/data/features.js.
 
 - If a feature in that dataset only specifies `properties`, we just use those
   properties for regex/substring matches against the properties used in the input CSS.
 - If a feature also specifies `values`, then we also require that the associated
   value matches one of those values.
-  
-TODO:
-- [x] Support @-rules
-- [ ] Allow each feature to have multiple instances of the match criteria laid
-  out above, so that different, disjoint (property, value) combinations can
-  be used to detect a feature.
-- [ ] Subfeatures, in to allow a slightly looser coupling with caniuse-db's
-  structure (for handling, e.g., partial support, the different flexbox versions, etc.)
-- [ ] Prefix-aware testing: i.e., pass along a list of prefixes used with a
-  given feature.  (This is low priority: just use autoprefixer.)
 
-
-# API Details: 
+# API Details:
 
 ## As a transform stream
 ```javascript

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ var doiuse = require('doiuse');
 
 postcss(doiuse({
   browsers:['ie >= 6', '> 1%'],
-  ignore: ['rem'],
+  ignore: ['rem'], // an optional array of features to ignore
   onFeatureUsage: function(usageInfo) {
     console.log(usageInfo.message);
   }
@@ -77,6 +77,7 @@ gulp.src(src, { cwd: process.cwd() })
       'ie >= 8',
       '> 1%'
     ],
+    ignore: ['rem'], // an optional array of features to ignore
     onFeatureUsage: function (usageInfo) {
       console.log(usageInfo.message)
     }
@@ -101,7 +102,7 @@ Refer to the data in /src/data/features.js.
 var doiuse = require('doiuse/stream');
 
 process.stdin
-  .pipe(doiuse(['ie >= 8', '> 1%']))
+  .pipe(doiuse({ browsers: ['ie >= 8', '> 1%'], ignore: ['rem'] }))
   .on('data', function (usageInfo) {
     console.log(JSON.stringify(usageInfo))
   })

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ var doiuse = require('doiuse');
 
 postcss(doiuse({
   browsers:['ie >= 6', '> 1%'],
+  ignore: ['rem'],
   onFeatureUsage: function(usageInfo) {
     console.log(usageInfo.message);
   }
@@ -114,6 +115,7 @@ Yields `UsageInfo` objects as described below.
 ```javascript
 {
   browsers: ['ie >= 8', '> 1%'] // an autoprefixer-like array of browsers.
+  ignore: ['rem'], // an optional array of features to ignore
   onFeatureUsage: function(usageInfo) { } // a callback for usages of features not supported by the selected browsers
 }
 ```

--- a/cli.js
+++ b/cli.js
@@ -20,10 +20,16 @@ var yargs = require('yargs')
     default: defaultBrowsers.join(', ')
   })
   .string('b')
+  .options('i', {
+    alias: 'ignore',
+    description: 'List of features to ignore.',
+    default: ''
+  })
+  .string('i')
   .options('l', {
     alias: 'list-only',
     description: 'Just show the browsers and features that would be tested by' +
-      'the specified browser crtieria, without actually processing any CSS.'
+      'the specified browser criteria, without actually processing any CSS.'
   })
   .options('v', {
     alias: 'verbose',
@@ -41,6 +47,7 @@ var yargs = require('yargs')
 var argv = yargs.argv
 
 argv.browsers = argv.browsers.split(',').map(function (s) {return s.trim()})
+argv.ignore = argv.ignore.split(',').map(function (s) {return s.trim()})
 
 // Informational output
 if (argv.l) { argv.v = ++argv.verbose }
@@ -91,11 +98,11 @@ out.pipe(process.stdout)
 if (argv._.length > 0) {
   argv._.forEach(function (file) {
     fs.createReadStream(file)
-    .pipe(doiuse(argv.browsers, file))
+    .pipe(doiuse({ browsers: argv.browsers, ignore: argv.ignore }, file))
     .pipe(out)
   })
 } else {
   process.stdin
-    .pipe(doiuse(argv.browsers))
+    .pipe(doiuse({ browsers: argv.browsers, ignore: argv.ignore }))
     .pipe(out)
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doiuse",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Lint CSS for browser support against caniuse database.",
   "main": "lib/doiuse.js",
   "scripts": {

--- a/src/doiuse.js
+++ b/src/doiuse.js
@@ -5,11 +5,19 @@ let Detector = require('./detect-feature-use')
 function doiuse (options) {
   let browserQuery = options.browsers
   let onFeatureUsage = options.onFeatureUsage
+  let ignore = options.ignore
 
   if (!browserQuery) {
     browserQuery = doiuse['default'].slice()
   }
-  let cb = onFeatureUsage ? onFeatureUsage : function () {}
+  let cb = function (usageInfo) {
+    if (ignore && ignore.indexOf(usageInfo.feature) !== -1) {
+      return
+    }
+    if (onFeatureUsage) {
+      onFeatureUsage(usageInfo)
+    }
+  }
   let {browsers, features} = missingSupport(browserQuery)
   let detector = new Detector(_.keys(features))
 

--- a/stream.js
+++ b/stream.js
@@ -9,15 +9,16 @@ var doiuse = require('./')
 module.exports = stream
 
 /**
- * @param {Array<string>} browsers  the browserslist browser selection
+ * @param {Object} options (browsers, ignore, etc.)
  * @param {string} [filename]  Filename for outputting source code locations.
  */
-function stream (browsers, filename) {
+function stream (options, filename) {
   var inp = rules()
   filename = filename || '<streaming css input>'
 
   var processor = postcss([doiuse({
-    browsers: browsers,
+    browsers: options.browsers,
+    ignore: options.ignore,
     onFeatureUsage: pushUsage
   })])
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -4,6 +4,7 @@ var path = require('path')
 var test = require('tape')
 
 var cssFile = path.join(__dirname, '/cases/gradient.css')
+
 var expected = '<streaming css input>:8:1: CSS Gradients not supported by: IE (8,9)\n' +
   '<streaming css input>:12:1: CSS Gradients not supported by: IE (8,9)\n' +
   '<streaming css input>:16:1: CSS Repeating Gradients not supported by: IE (8,9)\n' +
@@ -12,6 +13,14 @@ var expected = '<streaming css input>:8:1: CSS Gradients not supported by: IE (8
 var commands = {
   cat: ' cat ' + cssFile + ' | tee /dev/tty ',
   doiuse: ' node ' + path.join(__dirname, '../cli.js') + ' --browsers="IE >= 8" '
+}
+
+var expected_with_ignore = '<streaming css input>:16:1: CSS Repeating Gradients not supported by: IE (8,9)\n' +
+  '<streaming css input>:20:1: CSS Repeating Gradients not supported by: IE (8,9)\n'
+
+var commands_with_ignore = {
+  cat: ' cat ' + cssFile + ' | tee /dev/tty ',
+  doiuse: ' node ' + path.join(__dirname, '../cli.js') + ' --browsers="IE >= 8" --ignore="css-gradients" '
 }
 
 var exec = function (cmd, cb) {
@@ -29,6 +38,20 @@ test('cli command: piped input', function (t) {
 test('should take filename as input', function (t) {
   exec(commands.doiuse + cssFile, function (error, stdout, stderr) {
     t.equal(stdout, expected.replace(/<streaming css input>/g, cssFile))
+    t.end(error)
+  })
+})
+
+test('cli command with ignore: piped input', function (t) {
+  exec(commands_with_ignore.cat + ' | ' + commands_with_ignore.doiuse, function (error, stdout, stderr) {
+    t.equal(stdout, expected_with_ignore)
+    t.end(error)
+  })
+})
+
+test('should take filename as input with ignore', function (t) {
+  exec(commands_with_ignore.doiuse + cssFile, function (error, stdout, stderr) {
+    t.equal(stdout, expected_with_ignore.replace(/<streaming css input>/g, cssFile))
     t.end(error)
   })
 })

--- a/test/postcss-plugin.js
+++ b/test/postcss-plugin.js
@@ -35,3 +35,24 @@ test('calls back for unsupported feature usages', function (t) {
     t.end()
   })
 })
+
+test('ignores specified features and calls back for the others', function (t) {
+  var count, css
+  css = fs.readFileSync(require.resolve('./cases/gradient.css'))
+  count = 0
+  postcss(doiuse({
+    browsers: ['ie 8'],
+    ignore: [
+      'css-gradients'
+    ],
+    onFeatureUsage: function (usageInfo) {
+      count++
+      hasKeys(t, usageInfo, ['feature', 'featureData', 'usage', 'message'])
+      hasKeys(t, usageInfo.featureData, ['title', 'missing', 'missingData', 'caniuseData'])
+    }
+  }))
+    .process(css).then(function () {
+    t.equal(count, 2)
+    t.end()
+  })
+})

--- a/test/stream.js
+++ b/test/stream.js
@@ -8,14 +8,32 @@ var expected = [
   'background-img-opts'
 ]
 
+var expected_with_ignore = [
+  'background-img-opts'
+]
+
 test('streaming works', function (t) {
-  var s = stream('IE >= 8')
+  var s = stream({ browsers: 'IE >= 8' })
   s.pipe(through.obj(function (usage, enc, next) {
     t.equal(usage.feature, expected.shift())
     next()
   }, function (next) {
     next()
     t.equal(expected.length, 0)
+    t.end()
+  }))
+
+  s.end('div:nth-child(2n-1) { background-size: cover; }')
+})
+
+test('streaming works with ignore option', function (t) {
+  var s = stream({ browsers: 'IE >= 8', ignore: ['css-sel3'] })
+  s.pipe(through.obj(function (usage, enc, next) {
+    t.equal(usage.feature, expected_with_ignore.shift())
+    next()
+  }, function (next) {
+    next()
+    t.equal(expected_with_ignore.length, 0)
     t.end()
   }))
 


### PR DESCRIPTION
Per discussion in #21, add array of ignoring rules, i.e.:

`postcss(doiuse(opts)).process(css)`, where `opts` is:
```javascript
{
  browsers: ['ie >= 8', '> 1%'] // an autoprefixer-like array of browsers.
  ignore: ['rem'], // an optional array of features to ignore
  onFeatureUsage: function(usageInfo) { } // a callback for usages of features not supported by the selected browsers
}
```

A test was added as well, *for the PostCSS* plugin.

However, neither `stream.js` or `cli.js` were updated. The issue here is that it would likely break the current API, a decision I'd rather you make. Right now, the stream signature is:
```javascript
/**
 * @param {Array<string>} browsers  the browserslist browser selection
 * @param {string} [filename]  Filename for outputting source code locations.
 */
function stream (browsers, filename) {
```
It would have to be updated to support the `ignore` option (i.e. the array of features to ignore).
Either:
```javascript
function stream (browsers, ignore, filename) {
```
or:
```javascript
function stream (options, filename) {
```
where `options` would have the `browsers` and `ignore` keys.

Since `cli.js` uses `stream.js`, it would have to be updated as well, from:
```javascript
  process.stdin
    .pipe(doiuse(argv.browsers))
    .pipe(out)
```
to:
```javascript
  process.stdin
    .pipe(doiuse(argv.browsers, argv.ignore))
    .pipe(out)
```
or:
```javascript
  process.stdin
    .pipe(doiuse({browsers: argv.browsers, ignore: argv.ignore}))
    .pipe(out)
```
What do you think?