### PR TITLE
#24 use PostCSS result.warn API to send messages as well

### DIFF
--- a/src/doiuse.js
+++ b/src/doiuse.js
@@ -10,14 +10,6 @@ function doiuse (options) {
   if (!browserQuery) {
     browserQuery = doiuse['default'].slice()
   }
-  let cb = function (usageInfo) {
-    if (ignore && ignore.indexOf(usageInfo.feature) !== -1) {
-      return
-    }
-    if (onFeatureUsage) {
-      onFeatureUsage(usageInfo)
-    }
-  }
   let {browsers, features} = missingSupport(browserQuery)
   let detector = new Detector(_.keys(features))
 
@@ -29,27 +21,37 @@ function doiuse (options) {
       }
     },
 
-    postcss (css) {
+    postcss (css, result) {
       return detector.process(css, function ({feature, usage}) {
-        let loc = usage.source
-        loc.original = css.source.input.map ? {
-          start: css.source.input.map.consumer().originalPositionFor(loc.start),
-          end: css.source.input.map.consumer().originalPositionFor(loc.end)
-        } : {
-          start: loc.start,
-          end: loc.end
+        if (ignore && ignore.indexOf(feature) !== -1) {
+          return
         }
 
-        let message = (loc.original.start.source || loc.input.file || loc.input.from) + ':' +
-          loc.original.start.line + ':' + loc.original.start.column + ': ' +
-          features[feature].title + ' not supported by: ' + features[feature].missing
+        let message = features[feature].title + ' not supported by: ' +
+          features[feature].missing + ' (' + feature + ')'
 
-        return cb({
-          feature: feature,
-          featureData: features[feature],
-          usage: usage,
-          message: message
-        })
+        result.warn(message, { node: usage, plugin: 'doiuse' })
+
+        if (onFeatureUsage) {
+          let loc = usage.source
+          loc.original = css.source.input.map ? {
+            start: css.source.input.map.consumer().originalPositionFor(loc.start),
+            end: css.source.input.map.consumer().originalPositionFor(loc.end)
+          } : {
+            start: loc.start,
+            end: loc.end
+          }
+
+          message = (loc.original.start.source || loc.input.file || loc.input.from) + ':' +
+            loc.original.start.line + ':' + loc.original.start.column + ': ' + message
+
+          onFeatureUsage({
+            feature: feature,
+            featureData: features[feature],
+            usage: usage,
+            message: message
+          })
+        }
       })
     }
   }

--- a/test/cli.js
+++ b/test/cli.js
@@ -4,23 +4,23 @@ var path = require('path')
 var test = require('tape')
 
 var cssFile = path.join(__dirname, '/cases/gradient.css')
+var pathToCli = ' node ' + path.join(__dirname, '../cli.js')
+var catCss = ' cat ' + cssFile + ' | tee /dev/tty '
 
-var expected = '<streaming css input>:8:1: CSS Gradients not supported by: IE (8,9)\n' +
-  '<streaming css input>:12:1: CSS Gradients not supported by: IE (8,9)\n' +
-  '<streaming css input>:16:1: CSS Repeating Gradients not supported by: IE (8,9)\n' +
-  '<streaming css input>:20:1: CSS Repeating Gradients not supported by: IE (8,9)\n'
-
+var expected_css_gradients = '<streaming css input>:8:1: CSS Gradients not supported by: IE (8,9) (css-gradients)\n' +
+  '<streaming css input>:12:1: CSS Gradients not supported by: IE (8,9) (css-gradients)\n'
+var expected_css_repeating_gradients = '<streaming css input>:16:1: CSS Repeating Gradients not supported by: IE (8,9) (css-repeating-gradients)\n' +
+  '<streaming css input>:20:1: CSS Repeating Gradients not supported by: IE (8,9) (css-repeating-gradients)\n'
+var expected = expected_css_gradients + expected_css_repeating_gradients
 var commands = {
-  cat: ' cat ' + cssFile + ' | tee /dev/tty ',
-  doiuse: ' node ' + path.join(__dirname, '../cli.js') + ' --browsers="IE >= 8" '
+  cat: catCss,
+  doiuse: pathToCli + ' --browsers="IE >= 8" '
 }
 
-var expected_with_ignore = '<streaming css input>:16:1: CSS Repeating Gradients not supported by: IE (8,9)\n' +
-  '<streaming css input>:20:1: CSS Repeating Gradients not supported by: IE (8,9)\n'
-
+var expected_with_ignore = expected_css_repeating_gradients
 var commands_with_ignore = {
-  cat: ' cat ' + cssFile + ' | tee /dev/tty ',
-  doiuse: ' node ' + path.join(__dirname, '../cli.js') + ' --browsers="IE >= 8" --ignore="css-gradients" '
+  cat: catCss,
+  doiuse: pathToCli + ' --browsers="IE >= 8" --ignore="css-gradients" '
 }
 
 var exec = function (cmd, cb) {


### PR DESCRIPTION
This addresses issue #24 by pushing the warning message using the PostCSS [API](https://github.com/postcss/postcss/blob/master/docs/guidelines/plugin.md#32-use-resultwarn-for-warnings):
```
  result.warn(message, { node: usage, plugin: 'doiuse' }) 
```
This has no visible side-effect unless the warnings are handled downstream, either by looping over [the warnings array](https://github.com/postcss/postcss/blob/master/docs/api.md#resultwarnings) and outputting them to the console, or by using a pretty-printer like [`postcss-reporter`](https://github.com/postcss/postcss-reporter).

This PR also displays `feature` in parenthesis at the end of the message. This can in turn be leveraged to suppress the corresponding warning using the new [`ignore`](https://github.com/anandthakker/doiuse/pull/25) option. The tests were updated accordingly.

Here is an output example when using `doiuse` from [`webpack`](http://webpack.github.io/) + [`postcss-loader`](https://github.com/postcss/postcss-loader), note how it flows with other PostCSS plugins that comply with the `result.warn` API (here, [`stylelint`](https://github.com/stylelint/stylelint) and [`postcss-bem-linter`](https://github.com/postcss/postcss-bem-linter)):

```
$ webpack
src/css/App.css
2:5   ⚠  Expected indentation of 2 spaces (indentation) [stylelint]

src/css/Vote.css
13:1  ⚠  Invalid component selector ".Foo" [postcss-bem-linter]

src/css/typography.css
10:3  ⚠  rem (root em) units not supported by: IE (8,9,10) (rem) [doiuse]
14:3  ⚠  rem (root em) units not supported by: IE (8,9,10) (rem) [doiuse]
```

Thanks