### PR TITLE
use require() to load features-json data

### DIFF
--- a/src/missing-support.js
+++ b/src/missing-support.js
@@ -1,7 +1,6 @@
 let features = require('../data/features')
 let BrowserSelection = require('./browsers')
 let _ = require('lodash')
-let fs = require('fs')
 let formatBrowserName = require('./util').formatBrowserName
 
 function filterStats (browsers, stats) {
@@ -53,9 +52,7 @@ function missing (browserRequest) {
   let result = {}
 
   Object.keys(features).forEach((feature) => {
-    let json = fs.readFileSync(require.resolve('caniuse-db/features-json/' +
-      feature))
-    let featureData = JSON.parse(json)
+    let featureData = require('caniuse-db/features-json/' + feature)
     let missingData = filterStats(browsers, featureData.stats)
 
     // browsers missing support for this feature


### PR DESCRIPTION
I'm trying to `require()` the `features-json` data, so I can try to browserify `doiuse`, but I'm getting:
```
lcrouch:doiuse lcrouch$ node /Users/lcrouch/code/doiuse/cli.js --browsers="IE >= 8" --json /Users/lcrouch/code/doiuse/test/cases/gradient.css
[SyntaxError: Unexpected token o]
```

I'm not sure what would cause this? Or how to get better output - exactly where is the Unexpected token?