### PR TITLE
require fulldata for easier browserify

### DIFF
--- a/src/missing-support.js
+++ b/src/missing-support.js
@@ -3,6 +3,8 @@ let BrowserSelection = require('./browsers')
 let _ = require('lodash')
 let formatBrowserName = require('./util').formatBrowserName
 
+let caniuse = require('caniuse-db/fulldata-json/data-1.0')
+
 function filterStats (browsers, stats) {
   return _.transform(stats, (resultStats, versionData, browser) => {
     // filter only versions of selected browsers that don't support this
@@ -52,7 +54,7 @@ function missing (browserRequest) {
   let result = {}
 
   Object.keys(features).forEach((feature) => {
-    let featureData = require('caniuse-db/features-json/' + feature)
+    let featureData = caniuse.data[feature]
     let missingData = filterStats(browsers, featureData.stats)
 
     // browsers missing support for this feature


### PR DESCRIPTION
I don't expect this should be merged lightly ...

I changed the code to load the entire `fulldata-json/data-1.0.js` data from `caniuse-db`, so that the `doiuse` can be `browserify`'ed. (`browserify` doesn't do anything with the `require` call that includes the dynamic `feature` name.

This means the script will load the 935KB `.json` file instead of individually loading up to 326 4KB-7KB `.json` files from `features-json/`. I'm not sure which approach is better performance-wise, or if you care enough about it to run some kind of benchmark between them?