### PR TITLE
Proposal: `doiuse-disable` inline comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ gulp.src(src, { cwd: process.cwd() })
 # How it works
 In particular, the approach to detecting features usage is currently quite naive.
 
-Refer to the data in /src/data/features.js.
+<a name="features-list"></a>Refer to the data in [/data/features.js](data/features.js).
 
 - If a feature in that dataset only specifies `properties`, we just use those
   properties for regex/substring matches against the properties used in the input CSS.
@@ -144,6 +144,18 @@ And `usageInfo` looks like this:
 ```
     Called once for each usage of each css feature not supported by the selected
     browsers.
+
+## Ignoring file-specific rules: 
+For disabling some checks you can use just-in-place comments
+##### `/* doiuse-disable */`
+Disables checks of _all [features](#features-list)_
+##### `/* doiuse-disable feature */`
+Disables checks of _specified [feature(s)](#features-list)_ (can be comma separated list)
+##### `/* doiuse-enable */`
+Re-enables checks of _all [features](#features-list)_
+##### `/* doiuse-enable feature */`
+Enables checks of _specified [feature(s)](#features-list)_  (can be comma separated list)
+ - for following lines in file
 
 # [Contributing](CONTRIBUTING.md)
 

--- a/src/doiuse.js
+++ b/src/doiuse.js
@@ -4,7 +4,7 @@ let Detector = require('./detect-feature-use')
 let Multimatch = require('multimatch')
 
 function doiuse (options) {
-  let {browsers: browserQuery, onFeatureUsage, ignore, ignoreFiles} = options
+  let {browsers: browserQuery, onFeatureUsage, ignore: ignoreOptions, ignoreFiles} = options
 
   if (!browserQuery) {
     browserQuery = doiuse['default'].slice()
@@ -21,8 +21,11 @@ function doiuse (options) {
     },
 
     postcss (css, result) {
-      return detector.process(css, function ({feature, usage}) {
+      return detector.process(css, function ({feature, usage, ignore}) {
         if (ignore && ignore.indexOf(feature) !== -1) {
+          return
+        }
+        if (ignoreOptions && ignoreOptions.indexOf(feature) !== -1) {
           return
         }
 

--- a/test/cases/ignore-comment.css
+++ b/test/cases/ignore-comment.css
@@ -1,0 +1,25 @@
+/* doiuse-disable */
+disable-all {
+  display: flex;
+}
+
+/* doiuse-enable flexbox */
+enable-specific {
+  display: flex;
+}
+
+/* doiuse-disable flexbox, css-filters */
+disable-specific {
+  display: flex;
+  filter: brightness(50%);
+}
+
+/* doiuse-enable */
+enable-all {
+  display: flex;
+}
+
+/* doiuse-disable */
+/* applies to included files */
+@import "./ignore-include.css";
+/* but not to other file */

--- a/test/postcss-plugin.js
+++ b/test/postcss-plugin.js
@@ -107,3 +107,33 @@ test('ignores rules from some imported files, and not others', function (t) {
             t.end()
           })
 })
+
+test('ignores rules specified in comments', function (t) {
+  var count, ignoreCss, ignoreCssPath, processCss, processCssPath
+  ignoreCssPath = require.resolve('./cases/ignore-comment.css')
+  ignoreCss = fs.readFileSync(ignoreCssPath)
+
+  processCssPath = require.resolve('./cases/ignore-file.css')
+  processCss = fs.readFileSync(processCssPath)
+
+  count = 0
+
+  var processor = postcss([atImport(),
+           doiuse({
+             browsers: ['ie 6'],
+             onFeatureUsage: function (usageInfo) {
+               count++
+             }
+          })])
+
+  processor.process(ignoreCss, {from: ignoreCssPath})
+    .then(function () {
+      t.equal(count, 2)
+    }).then(function () {
+      processor.process(processCss, {from: processCssPath})
+        .then(function () {
+          t.equal(count, 3, 'inline css disabing rules must apply only to current file')
+          t.end()
+        })
+    })
+})


### PR DESCRIPTION
Implement `doiuse-disable` and `doiuse-enable` comments in css for ignoring rules per specific files and be more friendly to progressive enhancement
Like a [`istanbul ignore next`](https://github.com/gotwarlost/istanbul/blob/master/ignoring-code-for-coverage.md#the-interface), [`eslint-disable [rule]`](http://eslint.org/docs/user-guide/configuring#configuring-rules), …

#### Comment-rules usage: 
##### `/* doiuse-disable */`
Disables _all features_ checks
##### `/* doiuse-disable flexbox, transforms3d */`
Disables _flexbox_ checks
##### `/* doiuse-enable */`
Enables _all feature_ checks
##### `/* doiuse-enable flexbox */`
Enables _flexbox_ checks
 - for following lines in file

#### To be discussed:
Applying rules from file to `@import`ed by `postcss-import` files (now it applies)