### PR TITLE
Bump lodash from 3 -> 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "duplexer2": "0.0.2",
     "jsonfilter": "^1.1.2",
     "ldjson-stream": "^1.2.1",
-    "lodash": "^3.5.0",
+    "lodash": "^4.0.0",
     "multimatch": "^2.0.0",
     "postcss": "^5.0.8",
     "source-map": "^0.4.2",


### PR DESCRIPTION
Most modern js libs have made this bump. `doiuse` wasn't using any of the methods that changed between versions, so all tests still pass.