### PR TITLE
Add .json extension to caniuse-db require statements

### DIFF
--- a/src/missing-support.js
+++ b/src/missing-support.js
@@ -3,7 +3,7 @@ let BrowserSelection = require('./browsers')
 let _ = require('lodash')
 let formatBrowserName = require('./util').formatBrowserName
 
-let caniuse = require('caniuse-db/fulldata-json/data-1.0')
+let caniuse = require('caniuse-db/fulldata-json/data-1.0.json')
 
 function filterStats (browsers, stats) {
   return _.reduce(stats, function (resultStats, versionData, browser) {

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,4 @@
-let agents = require('caniuse-db/data').agents
+let agents = require('caniuse-db/data.json').agents
 
 module.exports = {
   formatBrowserName: function (browserKey, versions) {


### PR DESCRIPTION
I ran into an issue using the [stylelint-webpack-plugin](https://github.com/vieron/stylelint-webpack-plugin), which lists this library as a dependency. Specifically, my tests for my webpack config were failing like so:

![screenshot of failing tests](http://d.pr/i/2Lcn+)

I searched my `node_modules` folder for the offending require and noticed that all other projects that list this library import `caniuse-db/*` with the `.json` extension, except this one. 

![screenshot of other libraries that require doiuse](http://d.pr/i/6g1E+)

Since my test setup is not currently configured to resolve the `.json` extension (as I currently have no need to yet), this was causing my test to fail.

I could solve by adding `.json` to the list of extensions like so

```js
{
  "jest": {
    "moduleFileExtensions": [
      "js",
      "jsx",
      "json", // <----
      "css"
    ]
  }
}
```

... but really I'd only be doing this to make up for this change in a buried dependency, which doesn't feel right. Plus I'd probably have to add a comment in my code base so that other developers on my project wouldn't remove this, get the same error, and be scratching their heads as to why. 

Given that there seems to be some symmetry between other libraries that require JSON data from `caniuse-db`, I thought a better solution would be to open this PR and just add the extensions.

---

Let me know if I need to make any other edits to make this a well-formed PR; not a usual OS contributor. 😄 