### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.js]
+charset = utf-8
+
+[*.{js,json}]
+indent_style = space
+indent_size = 2
+
+[.travis.yml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Add [EditorConfig](http://editorconfig.org/) file to make it easier for contributors using an editor with EditorConfig format to write code that complies with [standard](https://github.com/feross/standard)'s indentation requirements.

Depends on #59.