### PR TITLE
Specify engines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.5.0",
   "description": "Lint CSS for browser support against caniuse database.",
   "main": "lib/doiuse.js",
+  "engines": {
+    "node": ">=0.12"
+  },
   "scripts": {
     "test": "standard && tape test/*.js",
     "babel": "babel -d lib/ src/",


### PR DESCRIPTION
This matches the Node version specified in `.travis.yml`.