### PR TITLE
Updating project for 3.0

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,6 @@
+.npmignore
+.editorconfig
+.travis.yml
+CONTRIBUTING.md
+test/
 src/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "node"
+  - stable
+  - "6"
+  - "4"

--- a/cli.js
+++ b/cli.js
@@ -10,7 +10,6 @@ var path = require('path')
 var _ = require('lodash')
 
 var formatBrowserName = require('./lib/util').formatBrowserName
-var defaultBrowsers = require('./').default
 var doiuse = require('./stream')
 
 var yargs = require('yargs')
@@ -21,7 +20,7 @@ var yargs = require('yargs')
   .options('b', {
     alias: 'browsers',
     description: 'Autoprefixer-like browser criteria.',
-    default: defaultBrowsers.join(', ')
+    default: browserslist.defaults.join(', ')
   })
   .string('b')
   .options('i', {

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "lodash": "^4.0.0",
     "multimatch": "^2.0.0",
     "postcss": "^6.0.1",
-    "source-map": "^0.4.2",
+    "source-map": "^0.5.6",
     "through2": "^0.6.3",
-    "yargs": "^3.5.4"
+    "yargs": "^8.0.1"
   },
   "devDependencies": {
     "babel": "^5.2.13",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/anandthakker/doiuse",
   "dependencies": {
-    "browserslist": "^1.1.1",
+    "browserslist": "^2.1.2",
     "caniuse-db": "^1.0.30000187",
     "css-rule-stream": "^1.1.0",
     "duplexer2": "0.0.2",
@@ -35,7 +35,7 @@
     "ldjson-stream": "^1.2.1",
     "lodash": "^4.0.0",
     "multimatch": "^2.0.0",
-    "postcss": "^5.0.8",
+    "postcss": "^6.0.1",
     "source-map": "^0.4.2",
     "through2": "^0.6.3",
     "yargs": "^3.5.4"
@@ -43,7 +43,7 @@
   "devDependencies": {
     "babel": "^5.2.13",
     "mock-fs": "^4.3.0",
-    "postcss-import": "^7.1.3",
+    "postcss-import": "^10.0.0",
     "standard": "^8.1.0",
     "tape": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "browserslist": "^2.1.2",
     "caniuse-db": "^1.0.30000187",
+    "caniuse-lite": "^1.0.30000667",
     "css-rule-stream": "^1.1.0",
     "duplexer2": "0.0.2",
     "jsonfilter": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "babel": "^5.2.13",
-    "mock-fs": "^3.12.1",
+    "mock-fs": "^4.3.0",
     "postcss-import": "^7.1.3",
     "standard": "^8.1.0",
     "tape": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   "homepage": "https://github.com/anandthakker/doiuse",
   "dependencies": {
     "browserslist": "^2.1.2",
-    "caniuse-db": "^1.0.30000187",
-    "caniuse-lite": "^1.0.30000667",
+    "caniuse-lite": "^1.0.30000669",
     "css-rule-stream": "^1.1.0",
     "duplexer2": "0.0.2",
     "jsonfilter": "^1.1.2",

--- a/src/browsers.js
+++ b/src/browsers.js
@@ -2,9 +2,9 @@
 var browserslist = require('browserslist')
 var _ = require('lodash')
 module.exports = class BrowserSelection {
-  constructor (query) {
+  constructor (query, from) {
     this.browsersRequest = query
-    this._list = browserslist(this.browsersRequest)
+    this._list = browserslist(this.browsersRequest, { from })
       .map((s) => s.split(' '))
   }
 

--- a/src/missing-support.js
+++ b/src/missing-support.js
@@ -3,7 +3,7 @@ let BrowserSelection = require('./browsers')
 let _ = require('lodash')
 let formatBrowserName = require('./util').formatBrowserName
 
-let caniuse = require('caniuse-db/fulldata-json/data-1.0.json')
+let caniuse = require('caniuse-lite')
 
 function filterStats (browsers, stats) {
   return _.reduce(stats, function (resultStats, versionData, browser) {
@@ -75,7 +75,7 @@ function missing (browserRequest) {
   let result = {}
 
   Object.keys(features).forEach(function (feature) {
-    const featureData = caniuse.data[feature]
+    const featureData = caniuse.feature(caniuse.features[feature])
     const lackData = filterStats(browsers, featureData.stats)
     const missingData = lackData.missing
     const partialData = lackData.partial

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,4 @@
-let agents = require('caniuse-db/data.json').agents
+let agents = require('caniuse-lite').agents
 
 module.exports = {
   formatBrowserName: function (browserKey, versions) {

--- a/stream.js
+++ b/stream.js
@@ -57,7 +57,7 @@ function stream (options, filename) {
         ocol = 1
       }
 
-      processor.process(rule.content, { map: { prev: mapper.toString() } })
+      processor.process(rule.content, { from: filename, map: { prev: mapper.toString() } })
         .then(function (result) { next() })
         .catch(handleError)
     } catch (e) {

--- a/test/postcss-plugin.js
+++ b/test/postcss-plugin.js
@@ -141,7 +141,7 @@ test('ignores rules specified in comments', function (t) {
 
 test('info with browserslist file', function (t) {
   mock({
-    'browserslist': 'Safari 8\nIE >= 11'
+    'browserslist': '# Comment\nSafari 8\nIE >= 11'
   })
 
   var actual = doiuse({}).info().browsers

--- a/test/stream.js
+++ b/test/stream.js
@@ -42,8 +42,9 @@ test('streaming works with ignore option', function (t) {
 
 test('gracefully emit error on bad browsers list', function (t) {
   t.plan(1)
-  stream({ browsers: 'Blargh!' })
-  .on('error', function (e) {
+  var s = stream({ browsers: 'Blargh!' })
+  s.on('error', function (e) {
     t.ok(e)
   })
+  s.end('a{}')
 })


### PR DESCRIPTION
@anandthakker I tried to make changes really small and updated only really necessary things:

1. I updated `.npmignore` so npm package will be smaller (I remove tests and development files).
2. I added new Node.js versions to Travis CI and remove 0.12 (anyway PostCSS 6 doesn’t support it).
3. I used `browserslist.defaults` instead of local defined list (the are same).
4. I used `browserslist(manually, { path })` API to load config files in Browserslist.
5. I replaced `caniuse-db` to `caniuse-lite`. `caniuse-lite` is 1 MB compared to 7 MB of `caniuse-db`. And Autoprefixer and Browserslist uses only `caniuse-lite`.
6. I updated `source-map` and `yargs` dependencies.