### PR TITLE
Remove default error from feature detect

### DIFF
--- a/src/detect-feature-use.js
+++ b/src/detect-feature-use.js
@@ -127,9 +127,6 @@ module.exports = class Detector {
           break
         case 'comment':
           this.comment(child, cb)
-          break
-        default:
-          throw new Error('Unkonwn node type ' + child.type)
       }
     })
   }


### PR DESCRIPTION
Currently doiuse will throw an error for unrecognised node types. Users using LESS with import statements are running into problems with this because the less parser introduced a new node type for import statements:

> I believe the Less parser introduced a new node type (import) to the AST and it is entitled to do so. All PostCSS plugins should probably ignore node types they don't recognise, rather than throwing an error, as this allows for additional node types to be added to the AST by either the PostCSS standard CSS parser or by any of other PostCSS parsers (postcss-less, postcss-scss, sugarss etc).

By ignoring unrecognised node types doiuse will only warn about known syntax, and we can leave the check for syntax validity to other tools.

See discussion in https://github.com/ismay/stylelint-no-unsupported-browser-features/issues/36 and https://github.com/stylelint/stylelint/issues/2904.

As users might depend on their build breaking because of this I'm intending to publish this as a breaking change (i.e. new major version).