### PR TITLE
Update font-unicode-range

### DIFF
--- a/data/features.js
+++ b/data/features.js
@@ -377,7 +377,6 @@ module.exports = {
   'css-touch-action': { properties: ['touch-action'] },
   'css-clip-path': { properties: ['clip-path'] },
   'font-unicode-range': {
-    atrules: ['font-face'],
     properties: ['unicode-range']
   },
   'css-font-stretch': { properties: ['font-stretch'] },

--- a/test/cases/font-face.css
+++ b/test/cases/font-face.css
@@ -1,0 +1,10 @@
+/*
+expect:
+fontface: 1
+*/
+
+@font-face {
+  font-family: "Open Sans";
+  src: url("assets/fonts/OpenSans-Semibold.woff") format("woff");
+  font-weight: 500;
+}


### PR DESCRIPTION
Hi! Here a problem with `font-unicode-range` rule. 
When `@font-face` doesnt have any `unicode-range` rule, doiuse lies.
See an example [there](https://doiuse.herokuapp.com/?url=&browsers=&css=%40font-face%20%7B%0A%20%20font-family%3A%20%22Open%20Sans%22%3B%0A%20%20src%3A%20url(%22assets%2Ffonts%2FOpenSans-Semibold.woff%22)%20format(%22woff%22)%3B%0A%20%20font-weight%3A%20500%3B%0A%7D%0A).