### PR TITLE
Conform to browserslist API

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -20,7 +20,7 @@ var yargs = require('yargs')
   .options('b', {
     alias: 'browsers',
     description: 'Autoprefixer-like browser criteria.',
-    default: browserslist.defaults.join(', ')
+    default: null // browserslist.defaults.join(', ')
   })
   .string('b')
   .options('i', {
@@ -73,7 +73,7 @@ if (argv.config) {
   }
 }
 
-argv.browsers = argv.browsers.split(',').map(function (s) { return s.trim() })
+argv.browsers && (argv.browsers = argv.browsers.split(',').map(function (s) { return s.trim() }))
 argv.ignore = argv.ignore.split(',').map(function (s) { return s.trim() })
 // Informational output
 if (argv.l) { argv.v = ++argv.verbose }

--- a/cli.js
+++ b/cli.js
@@ -20,7 +20,7 @@ var yargs = require('yargs')
   .options('b', {
     alias: 'browsers',
     description: 'Autoprefixer-like browser criteria.',
-    default: null // browserslist.defaults.join(', ')
+    default: null
   })
   .string('b')
   .options('i', {

--- a/src/browsers.js
+++ b/src/browsers.js
@@ -4,7 +4,7 @@ var _ = require('lodash')
 module.exports = class BrowserSelection {
   constructor (query, from) {
     this.browsersRequest = query
-    this._list = browserslist(this.browsersRequest, { from })
+    this._list = browserslist(this.browsersRequest, from ? { path: from } : {})
       .map((s) => s.split(' '))
   }
 


### PR DESCRIPTION
Commit a1bf895ecd48b5c4ba8e82227da3c33aaafc3a48 changed the browserslist
request from
    browserslist(this.browsersRequest)
to
    browserslist(this.browsersRequest, { from })

But in browserslist the option name for the path is 'path'. This commit
corrects this. Note that this means that before, since 'path' was not specified,
browserslist would fallback to the current working directory for the
config file look up.

With this commit, if no queries are specified, browserslist will look up
for a config file up from the specified path rather than the current working
directory. This conforms with autoprefixer behavior.