### PR TITLE
Upgrade browserslist and caniuse

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Unreleased
+Upgrade browserslist (3.1.1) and caniuse-lite (1.0.30000810) (#85)
+
 2017-10-09 - 4.0.0
 09db5fc (Breaking) No longer throws an error for unrecognised node types (see #75)
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "homepage": "https://github.com/anandthakker/doiuse",
   "dependencies": {
-    "browserslist": "^2.1.2",
-    "caniuse-lite": "^1.0.30000669",
+    "browserslist": "^3.1.1",
+    "caniuse-lite": "^1.0.30000810",
     "css-rule-stream": "^1.1.0",
     "duplexer2": "0.0.2",
     "jsonfilter": "^1.1.2",


### PR DESCRIPTION
Upgraded packages:

```
    "browserslist": "^3.1.1",
    "caniuse-lite": "^1.0.30000810",
```

Allows to specify in `browsers` new `dead` option https://github.com/ai/browserslist/blob/master/CHANGELOG.md#30

Fixes #84 