### PR TITLE
css-grid: implement display: grid; property

### DIFF
--- a/data/features.js
+++ b/data/features.js
@@ -303,7 +303,10 @@ module.exports = {
     properties: ['display'],
     values: ['inline-block']
   },
-  'css-grid': { unimplemented: true },
+  'css-grid': {
+    properties: ['display'],
+    values: ['grid', 'inline-grid']
+  },
   rem: {
     properties: [''],
     values: ['rem']


### PR DESCRIPTION
more information:
https://caniuse.com/css-grid
https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout

example:
```css
.foobar {
    display: grid; 
}
```
report this error:
```Unexpected browser feature "css-grid" is not supported by Safari 10, iOS Safari 10.0-10.2 and only partially supported by IE 11```

