### PR TITLE
Intrinsic width feature update with "stretch" value

### DIFF
--- a/data/features.js
+++ b/data/features.js
@@ -159,7 +159,8 @@ module.exports = {
       'max-content',
       'min-content',
       'fit-content',
-      'fill-available'
+      'fill-available',
+      'stretch'
     ]
   },
   'css3-cursors-newer': {


### PR DESCRIPTION
This pull request is created to resolve issue: https://github.com/anandthakker/doiuse/issues/131 - stretch value is missing in intrinsic width values array, so we don't get any warnings/errors when it is used even if browsers don't support it.