### PR TITLE
fix: Fix transform stream example

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ In particular, the approach to detecting features usage is currently quite naive
 ### As a transform stream
 
 ```javascript
-var doiuse = require('doiuse/stream');
+import DoIUse from 'doiuse/stream';
 
 process.stdin
-  .pipe(doiuse({ browsers: ['ie >= 8', '> 1%'], ignore: ['rem'] }))
+  .pipe(new DoIUse({ browsers: ['ie >= 8', '> 1%'], ignore: ['rem'] }))
   .on('data', function (usageInfo) {
     console.log(JSON.stringify(usageInfo))
   })


### PR DESCRIPTION
With [_As a transform stream_](https://github.com/anandthakker/doiuse#as-a-transform-stream) example in README, I have this error:


```
/home/regseb/testcase/index.js:4
  .pipe(doiuse({ browsers: ['ie >= 8', '> 1%'], ignore: ['rem'] }))
        ^

TypeError: Class constructor CssUsageDuplex cannot be invoked without 'new'
    at Object.<anonymous> (/home/regseb/testcase/index.js:4:9)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:23:47

Node.js v18.16.1
```