### PR TITLE
Fix Bug That Skips doiuse When Used With An Empty Configuration

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,7 +8,7 @@ import browserslist from 'browserslist';
 import ldjson from 'ldjson-stream';
 import yargs from 'yargs';
 
-import DoIUse from '../lib/DoIUse.js';
+import doIUse from '../lib/DoIUse.js';
 import CssUsageDuplex from '../lib/stream/CssUsageDuplex.js';
 import { formatBrowserName } from '../utils/util.js';
 
@@ -100,7 +100,7 @@ if (argv.l || argv.verbose >= 1) {
 }
 
 if (argv.verbose >= 2) {
-  const { features } = new DoIUse({ browsers }).info();
+  const { features } = doIUse({ browsers }).info();
   process.stdout.write('[doiuse] Unsupported features:\n');
   for (const feature of Object.values(features)) {
     process.stdout.write(`${feature.caniuseData.title}\n`);

--- a/exports/index.js
+++ b/exports/index.js
@@ -1,9 +1,2 @@
-import DoIUse from '../lib/DoIUse.js';
-
-/**
- * @param  {ConstructorParameters<typeof DoIUse>} options
- * @return {DoIUse}
- */
-export default function index(...options) {
-  return new DoIUse(...options);
-}
+// eslint-disable-next-line no-restricted-exports
+export { default } from '../lib/DoIUse.js';

--- a/lib/DoIUse.js
+++ b/lib/DoIUse.js
@@ -27,104 +27,111 @@ import Detector from './Detector.js';
  * @prop {string[]} [ignoreFiles]
  */
 
-export default class DoIUse {
-  static default = null;
-
-  /**
-   * @param {DoIUseOptions} [optionsOrBrowserQuery]
-   */
-  constructor(optionsOrBrowserQuery) {
-    const options = (typeof optionsOrBrowserQuery === 'string')
-      ? { browsers: optionsOrBrowserQuery }
-      : { ...optionsOrBrowserQuery };
-    this.browserQuery = options.browsers;
-    this.onFeatureUsage = options.onFeatureUsage;
-    this.ignoreOptions = options.ignore;
-    this.ignoreFiles = options.ignoreFiles;
-    this.info = this.info.bind(this);
-    this.postcss = this.postcss.bind(this);
+/** @type {import('postcss').TransformCallback} */
+function postcss(css, result) {
+  let from;
+  if (css.source && css.source.input) {
+    from = css.source.input.file;
   }
+  const { features } = BrowserSelection.missingSupport(this.browserQuery, from);
+  // @ts-expect-error Needs cast
+  const detector = new Detector(Object.keys(features));
 
-  /**
-   * @param {Object} [options]
-   * @param {ConstructorParameters<typeof BrowserSelection>[1]} [options.from]
-   */
-  info(options = {}) {
-    const { browsers, features } = BrowserSelection.missingSupport(this.browserQuery, options.from);
-
-    return {
-      browsers,
-      features,
-    };
-  }
-
-  /** @type {import('postcss').TransformCallback} */
-  postcss(css, result) {
-    let from;
-    if (css.source && css.source.input) {
-      from = css.source.input.file;
+  return detector.process(css, ({ feature, usage, ignore }) => {
+    if (ignore && ignore.includes(feature)) {
+      return;
     }
-    const { features } = BrowserSelection.missingSupport(this.browserQuery, from);
-    // @ts-expect-error Needs cast
-    const detector = new Detector(Object.keys(features));
 
-    return detector.process(css, ({ feature, usage, ignore }) => {
-      if (ignore && ignore.includes(feature)) {
-        return;
-      }
+    if (this.ignoreOptions && this.ignoreOptions.includes(feature)) {
+      return;
+    }
 
-      if (this.ignoreOptions && this.ignoreOptions.includes(feature)) {
-        return;
-      }
+    if (!usage.source) {
+      throw new Error('No source?');
+    }
+    if (this.ignoreFiles && multimatch(usage.source.input.from, this.ignoreFiles).length > 0) {
+      return;
+    }
 
+    const data = features[feature];
+    if (!data) {
+      throw new Error('No feature data?');
+    }
+    const messages = [];
+    if (data.missing) {
+      messages.push(`not supported by: ${data.missing}`);
+    }
+    if (data.partial) {
+      messages.push(`only partially supported by: ${data.partial}`);
+    }
+
+    let message = `${data.title} ${messages.join(' and ')} (${feature})`;
+
+    result.warn(message, { node: usage, plugin: 'doiuse' });
+
+    if (this.onFeatureUsage) {
       if (!usage.source) {
-        throw new Error('No source?');
+        throw new Error('No usage source?');
       }
-      if (this.ignoreFiles && multimatch(usage.source.input.from, this.ignoreFiles).length > 0) {
-        return;
-      }
-
-      const data = features[feature];
-      if (!data) {
-        throw new Error('No feature data?');
-      }
-      const messages = [];
-      if (data.missing) {
-        messages.push(`not supported by: ${data.missing}`);
-      }
-      if (data.partial) {
-        messages.push(`only partially supported by: ${data.partial}`);
+      const { start, input } = usage.source;
+      if (!start) {
+        throw new Error('No usage source start?');
       }
 
-      let message = `${data.title} ${messages.join(' and ')} (${feature})`;
+      const map = css.source && css.source.input.map;
+      const mappedStart = map && map.consumer().originalPositionFor(start);
 
-      result.warn(message, { node: usage, plugin: 'doiuse' });
+      const file = (mappedStart && mappedStart.source) || input.file || input.from;
+      const line = (mappedStart && mappedStart.line) || start.line;
+      const column = (mappedStart && mappedStart.column) || start.column;
 
-      if (this.onFeatureUsage) {
-        if (!usage.source) {
-          throw new Error('No usage source?');
-        }
-        const { start, input } = usage.source;
-        if (!start) {
-          throw new Error('No usage source start?');
-        }
+      message = `${file}:${line}:${column}: ${message}`;
 
-        const map = css.source && css.source.input.map;
-        const mappedStart = map && map.consumer().originalPositionFor(start);
-
-        const file = (mappedStart && mappedStart.source) || input.file || input.from;
-        const line = (mappedStart && mappedStart.line) || start.line;
-        const column = (mappedStart && mappedStart.column) || start.column;
-
-        message = `${file}:${line}:${column}: ${message}`;
-
-        this.onFeatureUsage({
-          feature,
-          featureData: features[feature],
-          usage,
-          message,
-        });
-      }
-    });
-  }
+      this.onFeatureUsage({
+        feature,
+        featureData: features[feature],
+        usage,
+        message,
+      });
+    }
+  });
 }
+
+/**
+ * @param {DoIUseOptions} [optionsOrBrowserQuery]
+ */
+export default function doIUse(optionsOrBrowserQuery) {
+  const pluginOptions = (typeof optionsOrBrowserQuery === 'string')
+    ? { browsers: optionsOrBrowserQuery }
+    : { ...optionsOrBrowserQuery };
+
+  const instance = {
+    browserQuery: pluginOptions.browsers,
+    onFeatureUsage: pluginOptions.onFeatureUsage,
+    ignoreOptions: pluginOptions.ignore,
+    ignoreFiles: pluginOptions.ignoreFiles,
+    /**
+     * @param {Object} [options]
+     * @param {ConstructorParameters<typeof BrowserSelection>[1]} [options.from]
+     */
+    info: function info(options = {}) {
+      const { browsers, features } = BrowserSelection
+        .missingSupport(this.browserQuery, options.from);
+
+      return {
+        browsers,
+        features,
+      };
+    },
+  };
+  instance.postcss = postcss.bind(instance);
+
+  return instance;
+}
+
+doIUse.default = null;
+doIUse.browserQuery = undefined;
+doIUse.onFeatureUsage = undefined;
+doIUse.ignoreOptions = undefined;
+doIUse.ignoreFiles = undefined;
+doIUse.postcss = postcss.bind(doIUse);

--- a/lib/stream/RuleUsageTransform.js
+++ b/lib/stream/RuleUsageTransform.js
@@ -4,7 +4,7 @@ import { Transform } from 'node:stream';
 import postcss from 'postcss';
 import sourcemap from 'source-map';
 
-import DoIUse from '../DoIUse.js';
+import doIUse from '../DoIUse.js';
 
 /** @typedef {import('../../data/features.js').FeatureKeys} FeatureKeys */
 /** @typedef {import('./SourceMapTransform.js').SourceMapTransformation} SourceMapTransformation */
@@ -28,7 +28,8 @@ export default class RuleUsageTransform extends Transform {
     super({
       objectMode: true,
     });
-    this.#processor = postcss([new DoIUse({
+    // @ts-expect-error This object shape still works with postcss
+    this.#processor = postcss([doIUse({
       browsers: options.browsers,
       ignore: options.ignore,
       onFeatureUsage: (usage) => {

--- a/test/postcss-plugin.js
+++ b/test/postcss-plugin.js
@@ -7,7 +7,7 @@ import postcss from 'postcss';
 import atImport from 'postcss-import';
 import { test } from 'tap';
 
-import DoIUse from '../lib/DoIUse.js';
+import doIUse from '../lib/DoIUse.js';
 
 import { hasKeys } from './utils.js';
 
@@ -15,7 +15,8 @@ const selfPath = dirname(fileURLToPath(import.meta.url));
 
 test('leaves css alone by default', (t) => {
   const css = fs.readFileSync(joinPath(selfPath, './cases/generic/gradient.css')).toString();
-  const out = postcss(new DoIUse({
+  // @ts-expect-error This object shape still works with postcss
+  const out = postcss(doIUse({
     browsers: [
       'ie >= 7',
       'safari >= 6',
@@ -29,7 +30,8 @@ test('leaves css alone by default', (t) => {
 test('calls back for unsupported feature usages', async (t) => {
   const css = fs.readFileSync(joinPath(selfPath, './cases/generic/gradient.css'));
   let count = 0;
-  await postcss(new DoIUse({
+  // @ts-expect-error This object shape still works with postcss
+  await postcss(doIUse({
     browsers: ['ie 8'],
     onFeatureUsage(usageInfo) {
       count += 1;
@@ -44,7 +46,8 @@ test('calls back for unsupported feature usages', async (t) => {
 test('ignores specified features and calls back for the others', async (t) => {
   const css = fs.readFileSync(joinPath(selfPath, './cases/generic/gradient.css'));
   let count = 0;
-  await postcss(new DoIUse({
+  // @ts-expect-error This object shape still works with postcss
+  await postcss(doIUse({
     browsers: ['ie 8'],
     ignore: [
       'css-gradients',
@@ -64,7 +67,8 @@ test('ignores specified files and calls back for others', async (t) => {
   const processCss = fs.readFileSync(joinPath(selfPath, './cases/generic/gradient.css'));
   let run = false;
 
-  const processor = postcss(new DoIUse({
+  // @ts-expect-error This object shape still works with postcss
+  const processor = postcss(doIUse({
     browsers: ['ie 6'],
     ignoreFiles: ['**/ignore-file.css'],
     onFeatureUsage() {
@@ -86,7 +90,7 @@ test('ignores rules from some imported files, and not others', async (t) => {
   let count = 0;
 
   await postcss([atImport(),
-    new DoIUse({
+    doIUse({
       browsers: ['ie 6'],
       ignoreFiles: ['**/ignore-file.css'],
       onFeatureUsage() {
@@ -107,7 +111,7 @@ test('ignores rules specified in comments', async (t) => {
   let count = 0;
 
   const processor = postcss([atImport(),
-    new DoIUse({
+    doIUse({
       browsers: ['ie 6'],
       onFeatureUsage() {
         count += 1;
@@ -128,7 +132,7 @@ test('info with browserslist file', (t) => {
     browserslist: '# Comment\nSafari 8\nIE >= 11',
   });
 
-  const actual = new DoIUse({}).info().browsers;
+  const actual = doIUse({}).info().browsers;
   const expected = [['ie', '11'], ['safari', '8']];
 
   t.same(actual, expected);
@@ -139,10 +143,10 @@ test('info with browserslist file', (t) => {
 });
 
 test('info with no browserslist file or browsers config', (t) => {
-  const actual = new DoIUse({}).info().browsers;
+  const actual = doIUse({}).info().browsers;
 
-  const expected = new DoIUse({
-    browsers: DoIUse.default,
+  const expected = doIUse({
+    browsers: doIUse.default,
   }).info().browsers;
 
   t.same(actual, expected);


### PR DESCRIPTION
BUG: postcss will skip doiuse if the configuration is in object format and the options for doiuse is set as an empty object.
Minimal repro: https://stackblitz.com/edit/vitejs-vite-f8xwph

A few things to note:
Plugin author (doiuse) -> exports plugin with options as the only parameter
postcss-load-config -> responsible for loading the configuration and returning a config object with a `plugins` field
postcss -> responsible for executing the transformation by using the result of postcss-load-config (`config.plugins`);

-----------------------------------------------------------------------------------------------------------------------------------------------------------
**THE FOLLOWING HAPPENS IN postcss-load-config:**

options = the postcss config file (e.g.: postcss.config.js)

if options.plugin is an array:
	1. store the plugins as is (plugins in arrays are stored as a require call, meaning the result is an import).
	2. if `plugin.postcss` is exactly true, store the plugin as the result of calling the default import of the plugin without any options.
	3. if `plugin.postcss` is not true but is still a truthy value, store the plugin as `plugin.postcss` (I think this is for old plugin shapes).	

else if options.plugins is an object:
	if `options.plugins[plugin]` (the options for a plugin, where plugin is the name of the plugin) is an empty object:
		postcss-load-config will store the plugin as a default import of the plugin. (KEEP THIS IN MIND)
	else:
		postcss-load-config will store the plugin as the result of calling the default import of the plugin with the options

After all this, store the results in an array.

-----------------------------------------------------------------------------------------------------------------------------------------------------------
**THE FOLLOWING HAPPENS IN postcss:**

1. if the array containing the plugins is inside a one-element array, flatten it.
2. if the property `postcss` exists in the top-level of the plugin and is a function, let it be the plugin itself

3. This is a loop [from postcss](https://github.com/postcss/postcss/blob/main/lib/processor.js) that loops through every plugin:
```
for (let i of plugins) {
	if (i.postcss === true) {
		i = i()
	} else if (i.postcss) {
        	i = i.postcss
	}

	if (typeof i === 'object' && Array.isArray(i.plugins)) {
		normalized = normalized.concat(i.plugins)
	} else if (typeof i === 'object' && i.postcssPlugin) {
		normalized.push(i)
	} else if (typeof i === 'function') {
		normalized.push(i)
	} else if (typeof i === 'object' && (i.parse || i.stringify)) {
		if (process.env.NODE_ENV !== 'production') {
			throw new Error(
				'PostCSS syntaxes cannot be used as plugins. Instead, please use ' +
				'one of the syntax/parser/stringifier options as outlined ' +
				'in your PostCSS runner documentation.'
			)
		}
	} else {
		throw new Error(i + ' is not a PostCSS plugin')
	}
}
```
Basically all you need to know about the code above is that doiuse currently fails all of the checks above and
thus doesn't even get pushed to `normalized` which is where the plugins will reside before finally being executed.

This is solely because you wrap `DoIUse` in an index function, and if you follow the code flow above, you'll notice that `DoIUse`
will arrive at the loop as a **reference** to the the wrapper function, since it doesn't actually contain the members of
`DoIUse` because it hasn't been instantiated, `i.postcss` will be undefined, and the reference will just be a regular function.
So the result is: your plugin will be sneakily skipped, without even a warning!

-----------------------------------------------------------------------------------------------------------------------------------------------------------

Other solutions:
- Document the fact that you can't use an empty object as the configuration for this plugin.
- This is all I got for now, I'll update this if anyone has another idea

I will also be opening an issue on the postcss-load-config repo to know why this distinction between empty configurations is a thing and if we can change it.

TLDR: doiuse is being skipped when used with empty options while in an object configuration because postcss-load-config modifies plugins in this exact scenario and the result makes postcss confused

Possibly related to #152.
Possibly related to [this comment](https://github.com/anandthakker/doiuse/issues/63#issuecomment-313936143)