### PR TITLE
Remove outdated ldjson-stream

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,9 +3,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { PassThrough } from 'node:stream';
+import { EOL } from 'node:os';
 
 import browserslist from 'browserslist';
-import ldjson from 'ldjson-stream';
 import yargs from 'yargs';
 
 import DoIUse from '../lib/DoIUse.js';
@@ -125,7 +125,12 @@ if (argv.help || (argv._.length === 0 && process.stdin.isTTY)) {
 /** @type {import("stream").Writable} */
 let outStream;
 if (argv.json) {
-  outStream = ldjson.serialize();
+  outStream = new PassThrough({
+    objectMode: true,
+    transform(object, encoding, next) {
+      next(null, JSON.stringify(object) + EOL);
+    },
+  });
 } else {
   outStream = new PassThrough({
     objectMode: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "doiuse",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doiuse",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.21.5",
         "caniuse-lite": "^1.0.30001487",
         "css-tokenize": "^1.0.1",
         "duplexify": "^4.1.2",
-        "ldjson-stream": "^1.2.1",
         "multimatch": "^5.0.0",
         "postcss": "^8.4.21",
         "source-map": "^0.7.4",
@@ -3950,15 +3949,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/ldjson-stream": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ldjson-stream/-/ldjson-stream-1.2.1.tgz",
-      "integrity": "sha512-xw/nNEXafuPSLu8NjjG3+atVVw+8U1APZAQylmwQn19Hgw6rC7QjHvP6MupnHWCrzSm9m0xs5QWkCLuRvBPjgQ==",
-      "dependencies": {
-        "split2": "^0.2.1",
-        "through2": "^0.6.1"
-      }
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -5630,14 +5620,6 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
       "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
       "dev": true
-    },
-    "node_modules/split2": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-0.2.1.tgz",
-      "integrity": "sha512-D/oTExYAkC9nWleOCTOyNmAuzfAT/6rHGBA9LIK7FVnGo13CSvrKCUzKenwH6U1s2znY9MqH6v0UQTEDa3vJmg==",
-      "dependencies": {
-        "through2": "~0.6.1"
-      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -7913,26 +7895,6 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
-    "node_modules/through2": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
-      "dependencies": {
-        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-        "xtend": ">=4.0.0 <4.1.0-0"
-      }
-    },
-    "node_modules/through2/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
     "node_modules/titleize": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
@@ -8325,14 +8287,6 @@
       "dev": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.16.5"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "caniuse-lite": "^1.0.30001487",
     "css-tokenize": "^1.0.1",
     "duplexify": "^4.1.2",
-    "ldjson-stream": "^1.2.1",
     "multimatch": "^5.0.0",
     "postcss": "^8.4.21",
     "source-map": "^0.7.4",


### PR DESCRIPTION
Hi,

This PR removes `ldjson-stream`, which hasn't been updated in 9 years and brings some very outdated dependencies (such as `through2` 0.6.5)

I'm replacing it with no dependency since the feature itself can be done easily in modern Node