### PR TITLE
fix(flexbox-gap): check for nodes

### DIFF
--- a/data/features/flexbox-gap.js
+++ b/data/features/flexbox-gap.js
@@ -8,7 +8,7 @@
  * @type {import('../features').Feature}
  */
 export default (rule) => {
-  if (!('some' in rule)) return false;
+  if (!('some' in rule) || !rule.nodes) return false;
 
   let hasFlexbox = false;
   let hasGap = false;


### PR DESCRIPTION
Resolves #195.

An at-rule like `@tailwind base;` does have `some` defined, but `nodes` [which is expected to exist](https://github.com/postcss/postcss/blob/5e6fd1302d2cc9a844ac99282b2b7745e4ac0ed3/lib/container.js#L298) is undefined.

I added a check for `nodes`, but you may change this PR to check for something more accurate, this is my first time into postcss.