### PR TITLE
Performance: cache browserSelection by resolved browserslist

### DIFF
--- a/lib/BrowserSelection.js
+++ b/lib/BrowserSelection.js
@@ -29,6 +29,9 @@ import { formatBrowserName } from '../utils/util.js';
  * @prop {Partial<Record<keyof FEATURES, MissingSupportResultStats>>} features
  */
 
+/** @type {Map<string, BrowserSupportStats>} */
+const browserSupportCache = new Map();
+
 export default class BrowserSelection {
   #list;
 
@@ -139,6 +142,11 @@ export default class BrowserSelection {
    * `feature-name` is a caniuse-db slug.
    */
   compileBrowserSupport() {
+    const cacheKey = JSON.stringify(this.#list);
+    if (browserSupportCache.has(cacheKey)) {
+      return browserSupportCache.get(cacheKey);
+    }
+
     /** @type {Partial<Record<keyof FEATURES, MissingSupportResultStats>>} */
     const result = {};
 
@@ -164,11 +172,9 @@ export default class BrowserSelection {
       }
     }
 
+    browserSupportCache.set(cacheKey, result);
     return result;
   }
-
-  /** @type {Map<string, MissingSupportResult>} @readonly */
-  static #missingSupportCache = new Map();
 
   /**
    * @see BrowserSelection.compileBrowserSupport
@@ -177,19 +183,10 @@ export default class BrowserSelection {
    */
   static missingSupport(...constructorParameters) {
     const [query, path] = constructorParameters;
-    // browserslist only uses `path` if `query` is not provided.
-    const key = query ? JSON.stringify(query) : path;
-
-    if (key && this.#missingSupportCache.has(key)) {
-      return this.#missingSupportCache.get(key);
-    }
-
     const selection = new BrowserSelection(query, path);
-    const result = {
+    return {
       browsers: selection.list(),
       features: selection.compileBrowserSupport(),
     };
-    if (key) this.#missingSupportCache.set(key, result);
-    return result;
   }
 }

--- a/lib/BrowserSelection.js
+++ b/lib/BrowserSelection.js
@@ -29,9 +29,6 @@ import { formatBrowserName } from '../utils/util.js';
  * @prop {Partial<Record<keyof FEATURES, MissingSupportResultStats>>} features
  */
 
-/** @type {Map<string, BrowserSupportStats>} */
-const browserSupportCache = new Map();
-
 export default class BrowserSelection {
   #list;
 
@@ -143,8 +140,8 @@ export default class BrowserSelection {
    */
   compileBrowserSupport() {
     const cacheKey = JSON.stringify(this.#list);
-    if (browserSupportCache.has(cacheKey)) {
-      return browserSupportCache.get(cacheKey);
+    if (BrowserSelection.#browserSupportCache.has(cacheKey)) {
+      return BrowserSelection.#browserSupportCache.get(cacheKey);
     }
 
     /** @type {Partial<Record<keyof FEATURES, MissingSupportResultStats>>} */
@@ -172,9 +169,12 @@ export default class BrowserSelection {
       }
     }
 
-    browserSupportCache.set(cacheKey, result);
+    BrowserSelection.#browserSupportCache.set(cacheKey, result);
     return result;
   }
+
+  /** @type {Map<string, BrowserSupportStats>} */
+  static #browserSupportCache = new Map();
 
   /**
    * @see BrowserSelection.compileBrowserSupport


### PR DESCRIPTION
Stylelint is very slow in our projects (1m10s for 1300 files, 8m 3200 files) when using [https://github.com/RJWadley/stylelint-no-unsupported-browser-features](stylelint-no-unsupported-browser-features). After some research, we isolated the issue to doiuse.

I see @cmrn added `missingSupportCache` in #182 — however, when `options.browsers` is not provided (the default), CSS file path is used as the cache key, so the cache is not actually shared between files. The benchmark linked https://github.com/anandthakker/doiuse/compare/master...RJWadley:doiuse:benchmark-2 explictly passses `browsers`, so it likely mismeasures the perf impact.

`browserslist` had a similar caching issue, which we just fixed in [v4.24.4](https://github.com/browserslist/browserslist/releases/tag/4.24.4) with [browserslist#862](https://github.com/browserslist/browserslist/pull/862) [browserslist#864](https://github.com/browserslist/browserslist/pull/864), so the config resolution should be fine now.

Building upon these enhancements, we can simplify caching: browserslist caches config resolution on its side, and doiuse only caches `compileBrowserSupport`.

This change speeds up stylelint 8x in our case, from 1m10s to 9s. @cmrn I see you have access to more benchmarks, maybe you could check them as well?